### PR TITLE
Refactor: move auth routes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ const userRoutes = require('./routes/user');
 const cartRoutes = require('./routes/cart');
 const dishRoutes = require('./routes/dish');
 const orderRoutes = require('./routes/order');
+const authRoutes = require('./routes/auth');
 const googleAuthRoutes = require('./routes/googleAuth');
 const AuthMiddleware = require('./middlewares/auth');
 const addressRoutes = require('./routes/address');
@@ -29,6 +30,7 @@ app.use(
 app.use('/api/user', userRoutes);
 app.use('/api/order', orderRoutes);
 app.use('/api/dish', dishRoutes);
+app.use('/api/auth', authRoutes);
 app.use('/api/auth', googleAuthRoutes);
 app.use('/api/address', addressRoutes);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const authController = require('../controllers/Auth');
+
+const router = express.Router();
+
+router.post('/signin', authController.signIn);
+router.post('/signup', authController.signUp);
+router.post('/cook/signup', authController.cookSignUp);
+router.get('/signout', authController.signOut);
+
+module.exports = router;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,14 +1,14 @@
 const express = require('express');
-const AuthController = require('../controllers/Auth');
+// const AuthController = require('../controllers/Auth');
 const AuthMiddleware = require('../middlewares/auth');
 const userController = require('../controllers/user');
 
 const router = express.Router();
 // handling Authentication Routes
-router.post('/signin', AuthController.signIn);
-router.post('/signup', AuthController.signUp);
-router.post('/cook/signup', AuthController.cookSignUp);
-router.get('/signout', AuthController.signOut);
+// router.post('/signin', AuthController.signIn);
+// router.post('/signup', AuthController.signUp);
+// router.post('/cook/signup', AuthController.cookSignUp);
+// router.get('/signout', AuthController.signOut);
 // User Controllers Routes
 
 router.get(


### PR DESCRIPTION
Issue #85 

Moved auth routes from routes/user.js to routes/auth.js and edited app.js accordingly. The auth endpoints are now as follows:

- /api/auth/signup
- /api/auth/cook/signup
- /api/auth/signin
- /api/auth/signout

